### PR TITLE
Change data fetch endpoint

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -8,7 +8,7 @@ let ejercicios = [];
 // Obtener datos del backend
 async function fetchEjercicios() {
   try {
-    const res = await fetch('ejercicios.json');
+    const res = await fetch('/ejercicios');
     ejercicios = await res.json();
     poblarZonaSelect();
     renderTable();

--- a/static/main.js
+++ b/static/main.js
@@ -8,7 +8,7 @@ let ejercicios = [];
 // Obtener datos del backend
 async function fetchEjercicios() {
   try {
-    const res = await fetch('ejercicios.json');
+    const res = await fetch('/ejercicios');
     ejercicios = await res.json();
     poblarZonaSelect();
     renderTable();


### PR DESCRIPTION
## Summary
- update JS fetch calls to use `/ejercicios` API endpoint

## Testing
- `python - <<'EOF'...` (Flask test client)
- `node test_table.js` (jsdom table render check)

------
https://chatgpt.com/codex/tasks/task_e_6854aba1a11483308837dd962d260e0e