### PR TITLE
Improve exercise load error hint

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -38,7 +38,7 @@ async function fetchEjercicios() {
     }
   } catch (err) {
     console.error('Error al obtener ejercicios:', err);
-    showError('Error al cargar los ejercicios. Por favor, recarga la página.');
+    showError('Error al cargar los ejercicios. Asegúrate de ejecutar `python app.py` o un servidor local y que el archivo `static/ejercicios.json` esté presente.');
   } finally {
     setLoading(false);
   }


### PR DESCRIPTION
## Summary
- clarify error message when loading exercises fails

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685721b7b8d483308aded24db88d8838